### PR TITLE
feat: add notification center with bell icon, grouped list, and DB persistence

### DIFF
--- a/drizzle/0008_calm_ben_grimm.sql
+++ b/drizzle/0008_calm_ben_grimm.sql
@@ -1,0 +1,58 @@
+CREATE TYPE "public"."notification_target" AS ENUM('review', 'comment');--> statement-breakpoint
+CREATE TYPE "public"."notification_type" AS ENUM('REACTION_ON_REVIEW', 'REACTION_ON_COMMENT', 'REPLY_ON_COMMENT', 'MENTION');--> statement-breakpoint
+CREATE TYPE "public"."reaction_type" AS ENUM('hype', 'sadness', 'plot_twist', 'skip');--> statement-breakpoint
+CREATE TABLE "comment_reactions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"comment_id" text NOT NULL,
+	"reaction_type" "reaction_type" NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "comment_reactions_user_id_comment_id_unique" UNIQUE("user_id","comment_id")
+);
+--> statement-breakpoint
+CREATE TABLE "notifications" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"type" "notification_type" NOT NULL,
+	"actor_id" text,
+	"target_id" text NOT NULL,
+	"target_type" "notification_target" NOT NULL,
+	"group_key" varchar(200) NOT NULL,
+	"read" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "review_comments" (
+	"id" text PRIMARY KEY NOT NULL,
+	"rating_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"parent_id" text,
+	"body" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"deleted_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "review_reactions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"rating_id" text NOT NULL,
+	"reaction_type" "reaction_type" NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "review_reactions_user_id_rating_id_unique" UNIQUE("user_id","rating_id")
+);
+--> statement-breakpoint
+ALTER TABLE "comment_reactions" ADD CONSTRAINT "comment_reactions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "comment_reactions" ADD CONSTRAINT "comment_reactions_comment_id_review_comments_id_fk" FOREIGN KEY ("comment_id") REFERENCES "public"."review_comments"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_actor_id_users_id_fk" FOREIGN KEY ("actor_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_comments" ADD CONSTRAINT "review_comments_rating_id_ratings_id_fk" FOREIGN KEY ("rating_id") REFERENCES "public"."ratings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_comments" ADD CONSTRAINT "review_comments_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_comments" ADD CONSTRAINT "review_comments_parent_id_review_comments_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."review_comments"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_reactions" ADD CONSTRAINT "review_reactions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "review_reactions" ADD CONSTRAINT "review_reactions_rating_id_ratings_id_fk" FOREIGN KEY ("rating_id") REFERENCES "public"."ratings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "comment_reactions_comment_id_idx" ON "comment_reactions" USING btree ("comment_id");--> statement-breakpoint
+CREATE INDEX "notifications_user_read_created_idx" ON "notifications" USING btree ("user_id","read","created_at");--> statement-breakpoint
+CREATE INDEX "notifications_user_group_created_idx" ON "notifications" USING btree ("user_id","group_key","created_at");--> statement-breakpoint
+CREATE INDEX "review_comments_rating_id_created_at_idx" ON "review_comments" USING btree ("rating_id","created_at");--> statement-breakpoint
+CREATE INDEX "review_comments_parent_id_idx" ON "review_comments" USING btree ("parent_id");--> statement-breakpoint
+CREATE INDEX "review_reactions_rating_id_idx" ON "review_reactions" USING btree ("rating_id");

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1237 @@
+{
+  "id": "2e90df73-bf82-489c-ad8a-c7d480dfeef7",
+  "prevId": "b55a55e1-b937-4fe5-bc8c-0008fb857a70",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activities": {
+      "name": "activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tmdb'"
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activities_user_id_idx": {
+          "name": "activities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_created_at_idx": {
+          "name": "activities_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activities_user_created_idx": {
+          "name": "activities_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activities_user_id_users_id_fk": {
+          "name": "activities_user_id_users_id_fk",
+          "tableFrom": "activities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comment_reactions": {
+      "name": "comment_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "reaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comment_reactions_comment_id_idx": {
+          "name": "comment_reactions_comment_id_idx",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comment_reactions_user_id_users_id_fk": {
+          "name": "comment_reactions_user_id_users_id_fk",
+          "tableFrom": "comment_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comment_reactions_comment_id_review_comments_id_fk": {
+          "name": "comment_reactions_comment_id_review_comments_id_fk",
+          "tableFrom": "comment_reactions",
+          "tableTo": "review_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comment_reactions_user_id_comment_id_unique": {
+          "name": "comment_reactions_user_id_comment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "comment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follows_follower_id_idx": {
+          "name": "follows_follower_id_idx",
+          "columns": [
+            {
+              "expression": "follower_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follows_following_id_idx": {
+          "name": "follows_following_id_idx",
+          "columns": [
+            {
+              "expression": "following_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_users_id_fk": {
+          "name": "follows_following_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_follower_id_following_id_pk": {
+          "name": "follows_follower_id_following_id_pk",
+          "columns": [
+            "follower_id",
+            "following_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "notification_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_read_created_idx": {
+          "name": "notifications_user_read_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_group_created_idx": {
+          "name": "notifications_user_group_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ratings": {
+      "name": "ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tmdb'"
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ratings_user_id_users_id_fk": {
+          "name": "ratings_user_id_users_id_fk",
+          "tableFrom": "ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ratings_user_id_source_tmdb_id_media_type_unique": {
+          "name": "ratings_user_id_source_tmdb_id_media_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "source",
+            "tmdb_id",
+            "media_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_comments": {
+      "name": "review_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rating_id": {
+          "name": "rating_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "review_comments_rating_id_created_at_idx": {
+          "name": "review_comments_rating_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "rating_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_comments_parent_id_idx": {
+          "name": "review_comments_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_comments_rating_id_ratings_id_fk": {
+          "name": "review_comments_rating_id_ratings_id_fk",
+          "tableFrom": "review_comments",
+          "tableTo": "ratings",
+          "columnsFrom": [
+            "rating_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_comments_user_id_users_id_fk": {
+          "name": "review_comments_user_id_users_id_fk",
+          "tableFrom": "review_comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_comments_parent_id_review_comments_id_fk": {
+          "name": "review_comments_parent_id_review_comments_id_fk",
+          "tableFrom": "review_comments",
+          "tableTo": "review_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_reactions": {
+      "name": "review_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_id": {
+          "name": "rating_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction_type": {
+          "name": "reaction_type",
+          "type": "reaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_reactions_rating_id_idx": {
+          "name": "review_reactions_rating_id_idx",
+          "columns": [
+            {
+              "expression": "rating_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_reactions_user_id_users_id_fk": {
+          "name": "review_reactions_user_id_users_id_fk",
+          "tableFrom": "review_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "review_reactions_rating_id_ratings_id_fk": {
+          "name": "review_reactions_rating_id_ratings_id_fk",
+          "tableFrom": "review_reactions",
+          "tableTo": "ratings",
+          "columnsFrom": [
+            "rating_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_reactions_user_id_rating_id_unique": {
+          "name": "review_reactions_user_id_rating_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "rating_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username_changed_at": {
+          "name": "username_changed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.watchlist": {
+      "name": "watchlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'tmdb'"
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watched": {
+          "name": "watched",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "watchlist_user_id_users_id_fk": {
+          "name": "watchlist_user_id_users_id_fk",
+          "tableFrom": "watchlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "watchlist_user_id_source_tmdb_id_media_type_unique": {
+          "name": "watchlist_user_id_source_tmdb_id_media_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "source",
+            "tmdb_id",
+            "media_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.notification_target": {
+      "name": "notification_target",
+      "schema": "public",
+      "values": [
+        "review",
+        "comment"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "REACTION_ON_REVIEW",
+        "REACTION_ON_COMMENT",
+        "REPLY_ON_COMMENT",
+        "MENTION"
+      ]
+    },
+    "public.reaction_type": {
+      "name": "reaction_type",
+      "schema": "public",
+      "values": [
+        "hype",
+        "sadness",
+        "plot_twist",
+        "skip"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1777688997000,
       "tag": "0007_comment_reactions",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1777820955275,
+      "tag": "0008_calm_ben_grimm",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/comment-reactions/route.ts
+++ b/src/app/api/comment-reactions/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { commentReactions, reviewComments } from "@/lib/schema";
 import { eq, and } from "drizzle-orm";
+import { createNotification } from "@/lib/notifications/create";
 
 const VALID_TYPES = ["hype", "sadness", "plot_twist", "skip"] as const;
 type ValidReactionType = (typeof VALID_TYPES)[number];
@@ -32,9 +33,9 @@ export async function POST(req: NextRequest) {
 
   const userId = session.user.id;
 
-  // Validate commentId exists
+  // Validate commentId exists and get author
   const [commentRow] = await db
-    .select({ id: reviewComments.id })
+    .select({ id: reviewComments.id, userId: reviewComments.userId })
     .from(reviewComments)
     .where(eq(reviewComments.id, commentId))
     .limit(1);
@@ -69,6 +70,21 @@ export async function POST(req: NextRequest) {
       commentId,
       reactionType: type,
     });
+
+    // Notification side-effect: notify comment author of new reaction
+    try {
+      if (commentRow.userId !== userId) {
+        await createNotification({
+          type: "REACTION_ON_COMMENT",
+          actorId: userId,
+          recipientId: commentRow.userId,
+          targetId: commentId,
+          targetType: "comment",
+        });
+      }
+    } catch (err) {
+      console.error("[comment-reactions notification]", err);
+    }
   }
 
   // Build summary of all reactions for this comment

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -3,6 +3,8 @@ import { auth } from "@/auth";
 import { db } from "@/lib/db";
 import { reviewComments, ratings, users, commentReactions } from "@/lib/schema";
 import { eq, and, asc, inArray, isNull } from "drizzle-orm";
+import { createNotification } from "@/lib/notifications/create";
+import { parseMentions } from "@/lib/notifications/mention-parse";
 
 // ─── GET: fetch comments for a rating (public) ─────────────────────────────────
 
@@ -141,6 +143,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Rating not found" }, { status: 404 });
     }
 
+    let parentAuthorId: string | null = null;
+
     // If parentId provided, validate it exists and belongs to same rating
     if (parentId) {
       if (typeof parentId !== "string") {
@@ -148,7 +152,7 @@ export async function POST(req: NextRequest) {
       }
 
       const [parentRow] = await db
-        .select({ id: reviewComments.id, ratingId: reviewComments.ratingId })
+        .select({ id: reviewComments.id, ratingId: reviewComments.ratingId, userId: reviewComments.userId })
         .from(reviewComments)
         .where(eq(reviewComments.id, parentId))
         .limit(1);
@@ -163,6 +167,8 @@ export async function POST(req: NextRequest) {
           { status: 400 }
         );
       }
+
+      parentAuthorId = parentRow.userId;
     }
 
     // Insert the comment
@@ -178,6 +184,36 @@ export async function POST(req: NextRequest) {
         parentId: resolvedParentId,
       })
       .returning();
+
+    // ─── Notification side-effects ──────────────────────────────────────────
+    try {
+      const commenterId = session.user.id;
+
+      // REPLY_ON_COMMENT: if replying to someone else's comment
+      if (resolvedParentId && parentAuthorId && parentAuthorId !== commenterId) {
+        await createNotification({
+          type: "REPLY_ON_COMMENT",
+          actorId: commenterId,
+          recipientId: parentAuthorId,
+          targetId: resolvedParentId,
+          targetType: "comment",
+        });
+      }
+
+      // MENTION: parse @username mentions in the body
+      const mentionedIds = await parseMentions(trimmedBody, commenterId);
+      for (const mentionedId of mentionedIds) {
+        await createNotification({
+          type: "MENTION",
+          actorId: commenterId,
+          recipientId: mentionedId,
+          targetId: inserted.id,
+          targetType: "comment",
+        });
+      }
+    } catch (err) {
+      console.error("[comments notification]", err);
+    }
 
     // Fetch the inserted comment with user info
     const [comment] = await db

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,242 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/lib/db";
+import { notifications, users, ratings, reviewComments } from "@/lib/schema";
+import { eq, desc, and, sql, inArray } from "drizzle-orm";
+import { groupNotifications } from "@/lib/notifications/group";
+
+// ─── GET: paginated grouped notification list ──────────────────────────────────
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10) || 1);
+  const limit = Math.min(50, Math.max(1, parseInt(searchParams.get("limit") ?? "20", 10) || 20));
+  const offset = (page - 1) * limit;
+
+  try {
+    const userId = session.user.id;
+
+    // Fetch notifications with actor and target data
+    const rawRows = await db
+      .select({
+        id: notifications.id,
+        userId: notifications.userId,
+        type: notifications.type,
+        actorId: notifications.actorId,
+        targetId: notifications.targetId,
+        targetType: notifications.targetType,
+        groupKey: notifications.groupKey,
+        read: notifications.read,
+        createdAt: notifications.createdAt,
+        actorName: users.name,
+        actorImage: users.image,
+      })
+      .from(notifications)
+      .leftJoin(users, eq(notifications.actorId, users.id))
+      .where(eq(notifications.userId, userId))
+      .orderBy(desc(notifications.createdAt))
+      .limit(limit)
+      .offset(offset);
+
+    // Count total and unread
+    const [countResult, unreadResult] = await Promise.all([
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(notifications)
+        .where(eq(notifications.userId, userId)),
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(notifications)
+        .where(and(eq(notifications.userId, userId), eq(notifications.read, false))),
+    ]);
+
+    // Batch-fetch target previews and navigation URLs
+    const targetPreviewMap: Record<string, string | null> = {};
+    const navigateToMap: Record<string, string | null> = {};
+
+    if (rawRows.length > 0) {
+      const reviewIds = rawRows
+        .filter((r) => r.targetType === "review")
+        .map((r) => r.targetId);
+
+      const commentIds = rawRows
+        .filter((r) => r.targetType === "comment")
+        .map((r) => r.targetId);
+
+      if (reviewIds.length > 0) {
+        const reviewRows = await db
+          .select({
+            id: ratings.id,
+            review: ratings.review,
+            tmdbId: ratings.tmdbId,
+            source: ratings.source,
+            mediaType: ratings.mediaType,
+          })
+          .from(ratings)
+          .where(inArray(ratings.id, reviewIds));
+
+        for (const row of reviewRows) {
+          targetPreviewMap[row.id] = row.review
+            ? row.review.substring(0, 50)
+            : null;
+
+          if (row.source === "anilist") {
+            navigateToMap[row.id] = `/anime/${row.tmdbId}`;
+          } else {
+            navigateToMap[row.id] = `/title/${row.mediaType}/${row.tmdbId}`;
+          }
+        }
+      }
+
+      if (commentIds.length > 0) {
+        // Fetch comment body + parent rating for navigation
+        const commentRows = await db
+          .select({
+            id: reviewComments.id,
+            body: reviewComments.body,
+            ratingId: reviewComments.ratingId,
+            deletedAt: reviewComments.deletedAt,
+          })
+          .from(reviewComments)
+          .where(inArray(reviewComments.id, commentIds));
+
+        for (const row of commentRows) {
+          // Show deleted content message when deletedAt is set
+          if (row.deletedAt != null) {
+            targetPreviewMap[row.id] = null;
+          } else {
+            targetPreviewMap[row.id] = row.body.substring(0, 50);
+          }
+        }
+
+        // Batch-fetch parent rating metadata for comment navigation
+        const commentRatingIds = [...new Set(commentRows.map((c) => c.ratingId))];
+        if (commentRatingIds.length > 0) {
+          const ratingRows = await db
+            .select({
+              id: ratings.id,
+              tmdbId: ratings.tmdbId,
+              source: ratings.source,
+              mediaType: ratings.mediaType,
+            })
+            .from(ratings)
+            .where(inArray(ratings.id, commentRatingIds));
+
+          const ratingIdToUrl = new Map<string, string>();
+          for (const row of ratingRows) {
+            ratingIdToUrl.set(
+              row.id,
+              row.source === "anilist"
+                ? `/anime/${row.tmdbId}`
+                : `/title/${row.mediaType}/${row.tmdbId}`
+            );
+          }
+
+          // Map comment ID → parent rating URL
+          for (const row of commentRows) {
+            const url = ratingIdToUrl.get(row.ratingId);
+            if (url) {
+              navigateToMap[row.id] = url;
+            }
+          }
+        }
+      }
+    }
+
+    // Map raw rows to format expected by groupNotifications
+    const mappedRows = rawRows.map((row) => ({
+      ...row,
+      targetPreview: targetPreviewMap[row.targetId] ?? null,
+    }));
+
+    const items = groupNotifications(mappedRows, { targetPreviewMap, navigateToMap });
+
+    const totalCount = countResult[0]?.count ?? 0;
+    const unreadCount = unreadResult[0]?.count ?? 0;
+    const hasMore = offset + limit < totalCount;
+
+    return NextResponse.json({ items, unreadCount, hasMore });
+  } catch (err) {
+    console.error("[notifications GET]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+// ─── PATCH: mark notifications as read ────────────────────────────────────────
+
+export async function PATCH(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: { notificationIds?: string[]; groupKey?: string };
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+
+  const userId = session.user.id;
+
+  try {
+    const { notificationIds, groupKey } = body;
+
+    // Mark by groupKey (mark all notifications in the group as read)
+    if (groupKey) {
+      const result = await db
+        .update(notifications)
+        .set({ read: true })
+        .where(
+          and(
+            eq(notifications.userId, userId),
+            eq(notifications.groupKey, groupKey),
+            eq(notifications.read, false)
+          )
+        )
+        .returning({ id: notifications.id });
+
+      return NextResponse.json({
+        success: true,
+        updatedCount: result.length,
+      });
+    }
+
+    if (notificationIds && notificationIds.length > 0) {
+      // Mark specific notifications as read
+      await db
+        .update(notifications)
+        .set({ read: true })
+        .where(
+          and(
+            eq(notifications.userId, userId),
+            inArray(notifications.id, notificationIds)
+          )
+        );
+
+      return NextResponse.json({ success: true, updatedCount: notificationIds.length });
+    }
+
+    // Mark ALL as read
+    const result = await db
+      .update(notifications)
+      .set({ read: true })
+      .where(
+        and(eq(notifications.userId, userId), eq(notifications.read, false))
+      )
+      .returning({ id: notifications.id });
+
+    return NextResponse.json({
+      success: true,
+      updatedCount: result.length,
+    });
+  } catch (err) {
+    console.error("[notifications PATCH]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/notifications/unread-count/route.ts
+++ b/src/app/api/notifications/unread-count/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/lib/db";
+import { notifications } from "@/lib/schema";
+import { eq, and, sql } from "drizzle-orm";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const [result] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(notifications)
+      .where(
+        and(
+          eq(notifications.userId, session.user.id),
+          eq(notifications.read, false)
+        )
+      );
+
+    return NextResponse.json({ count: result?.count ?? 0 });
+  } catch (err) {
+    console.error("[notifications unread-count]", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/reactions/route.ts
+++ b/src/app/api/reactions/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { db } from "@/lib/db";
-import { reviewReactions } from "@/lib/schema";
+import { reviewReactions, ratings } from "@/lib/schema";
 import { eq, and } from "drizzle-orm";
+import { createNotification } from "@/lib/notifications/create";
 
 const VALID_TYPES = ["hype", "sadness", "plot_twist", "skip"] as const;
 type ValidReactionType = (typeof VALID_TYPES)[number];
@@ -58,6 +59,28 @@ export async function POST(req: NextRequest) {
       ratingId,
       reactionType: type,
     });
+
+    // Notification side-effect: notify review author of new reaction
+    try {
+      const [ratingRow] = await db
+        .select({ userId: ratings.userId })
+        .from(ratings)
+        .where(eq(ratings.id, ratingId))
+        .limit(1);
+
+      if (ratingRow && ratingRow.userId !== userId) {
+        await createNotification({
+          type: "REACTION_ON_REVIEW",
+          actorId: userId,
+          recipientId: ratingRow.userId,
+          targetId: ratingId,
+          targetType: "review",
+        });
+      }
+    } catch (err) {
+      // Fire-and-forget: don't fail the reaction request if notification fails
+      console.error("[reactions notification]", err);
+    }
   }
 
   // Build summary of all reactions for this rating

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -8,6 +8,7 @@ import { useSession, signOut } from "next-auth/react";
 import { Search, Loader2, Film, Tv, Sparkles, UserCircle, LogOut } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { t } from "@/lib/i18n";
+import { NotificationBell } from "@/components/notifications/NotificationBell";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -178,6 +179,7 @@ export function Navbar() {
 
       {/* Auth area */}
       <div className="flex items-center gap-3">
+        <NotificationBell />
         {session?.user ? (
           <DropdownMenu>
             <DropdownMenuTrigger className="flex items-center gap-2.5 hover:opacity-80 transition-opacity">

--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Bell } from "lucide-react";
+import { useSession } from "next-auth/react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuPositioner,
+  DropdownMenuPopup,
+} from "@/components/ui/dropdown-menu";
+import { NotificationDropdown } from "@/components/notifications/NotificationDropdown";
+
+export function NotificationBell() {
+  const { data: session } = useSession();
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const fetchUnreadCount = useCallback(async () => {
+    if (!session?.user?.id) return;
+    try {
+      const res = await fetch("/api/notifications/unread-count");
+      if (!res.ok) return;
+      const data = await res.json();
+      setUnreadCount(data.count ?? 0);
+    } catch {
+      // Silently fail
+    }
+  }, [session?.user?.id]);
+
+  // Fetch on mount
+  useEffect(() => {
+    fetchUnreadCount();
+  }, [fetchUnreadCount]);
+
+  // Poll on visibility change
+  useEffect(() => {
+    function handleVisibilityChange() {
+      if (document.visibilityState === "visible") {
+        fetchUnreadCount();
+      }
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [fetchUnreadCount]);
+
+  const handleMarkAllRead = useCallback(() => {
+    setUnreadCount(0);
+  }, []);
+
+  const badgeLabel =
+    unreadCount === 0
+      ? null
+      : unreadCount > 99
+        ? "99+"
+        : String(unreadCount);
+
+  // Hidden when guest
+  if (!session?.user?.id) return null;
+
+  return (
+    <DropdownMenu
+      open={dropdownOpen}
+      onOpenChange={(open: boolean) => {
+        setDropdownOpen(open);
+        if (open) {
+          fetchUnreadCount();
+        }
+      }}
+    >
+      <DropdownMenuTrigger className="relative p-1.5 rounded-full hover:bg-accent transition-colors">
+        <Bell size={18} className="text-muted-foreground" />
+        {badgeLabel && (
+          <span
+            className={`
+              absolute -top-0.5 -right-0.5
+              min-w-[18px] h-[18px] flex items-center justify-center
+              rounded-full bg-cyan-500 text-white
+              text-[10px] font-bold leading-none
+              px-1
+            `}
+          >
+            {badgeLabel}
+          </span>
+        )}
+      </DropdownMenuTrigger>
+
+      <DropdownMenuPositioner align="end" sideOffset={12}>
+        <DropdownMenuPopup className="w-[360px] p-0 max-h-[480px] overflow-hidden">
+          <NotificationDropdown onMarkAllRead={handleMarkAllRead} />
+        </DropdownMenuPopup>
+      </DropdownMenuPositioner>
+    </DropdownMenu>
+  );
+}

--- a/src/components/notifications/NotificationDropdown.tsx
+++ b/src/components/notifications/NotificationDropdown.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Loader2 } from "lucide-react";
+import { NotificationItem } from "@/components/notifications/NotificationItem";
+import type { NotificationGroup } from "@/lib/notifications/group";
+import { t } from "@/lib/i18n";
+
+interface NotificationResponse {
+  items: NotificationGroup[];
+  unreadCount: number;
+  hasMore: boolean;
+}
+
+interface NotificationDropdownProps {
+  onMarkAllRead: () => void;
+}
+
+export function NotificationDropdown({ onMarkAllRead }: NotificationDropdownProps) {
+  const [data, setData] = useState<NotificationResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const fetchNotifications = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const res = await fetch("/api/notifications?limit=20");
+      if (!res.ok) throw new Error("Failed to fetch");
+      const json: NotificationResponse = await res.json();
+      setData(json);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchNotifications();
+  }, [fetchNotifications]);
+
+  const handleItemClick = useCallback(
+    async (group: NotificationGroup) => {
+      // Mark the entire group as read
+      try {
+        await fetch("/api/notifications", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ groupKey: group.groupKey }),
+        });
+      } catch {
+        // Fire-and-forget
+      }
+
+      // Navigate to target if URL is available
+      if (group.navigateTo) {
+        window.location.href = group.navigateTo;
+      }
+    },
+    []
+  );
+
+  const handleMarkAllRead = async () => {
+    try {
+      await fetch("/api/notifications", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      onMarkAllRead();
+      // Refresh the list
+      fetchNotifications();
+    } catch {
+      // Silently fail
+    }
+  };
+
+  // Empty state
+  if (!loading && !error && data && data.items.length === 0) {
+    return (
+      <div className="w-[360px] max-h-[480px] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+          <h3 className="text-sm font-semibold text-foreground">
+            Notificaciones
+          </h3>
+        </div>
+        {/* Empty state message */}
+        <div className="flex-1 flex items-center justify-center py-12">
+          <p className="text-sm text-muted-foreground text-center px-4">
+            {(t as unknown as Record<string, Record<string, string>>).notifications?.empty ??
+              "No tienes notificaciones todavía"}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-[360px] max-h-[480px] flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+        <h3 className="text-sm font-semibold text-foreground">
+          Notificaciones
+        </h3>
+        {data && data.unreadCount > 0 && (
+          <span className="text-[10px] text-muted-foreground bg-accent px-2 py-0.5 rounded-full">
+            {data.unreadCount} sin leer
+          </span>
+        )}
+      </div>
+
+      {/* Scrollable list */}
+      <div className="flex-1 overflow-y-auto max-h-[360px]">
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 size={20} className="animate-spin text-muted-foreground" />
+          </div>
+        ) : error ? (
+          <div className="px-4 py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              No se pudieron cargar las notificaciones.
+            </p>
+          </div>
+        ) : data ? (
+          <div className="py-1">
+            {data.items.map((group) => (
+              <NotificationItem
+                key={group.groupKey}
+                group={group}
+                onClick={handleItemClick}
+              />
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      {/* Footer: Mark all as read */}
+      {data && data.items.length > 0 && (
+        <div className="border-t border-border px-3 py-2">
+          <button
+            onClick={handleMarkAllRead}
+            className="w-full text-center text-xs text-cyan-400 hover:text-cyan-300 transition-colors py-1"
+          >
+            {(t as unknown as Record<string, Record<string, string>>).notifications?.markAllRead ??
+              "Marcar todas como le\u00eddas"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Heart, MessageCircle, AtSign, Star } from "lucide-react";
+import type { NotificationGroup, GroupedActor } from "@/lib/notifications/group";
+import { formatActorNames } from "@/lib/notifications/group";
+import { t } from "@/lib/i18n";
+
+// ─── Time-ago helper ──────────────────────────────────────────────────────────
+
+function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const diffMinutes = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+  const diffMonths = Math.floor(diffDays / 30);
+
+  if (diffMinutes < 1) return "ahora";
+  if (diffMinutes < 60) return `hace ${diffMinutes}min`;
+  if (diffHours < 24) return `hace ${diffHours}h`;
+  if (diffDays === 1) return "Ayer";
+  if (diffDays < 30) return `hace ${diffDays}d`;
+  return `hace ${diffMonths}mes`;
+}
+
+// ─── Notification type config ─────────────────────────────────────────────────
+
+const typeConfig: Record<string, { icon: typeof Heart; color: string }> = {
+  REACTION_ON_REVIEW: { icon: Heart, color: "text-rose-400" },
+  REACTION_ON_COMMENT: { icon: Heart, color: "text-rose-400" },
+  REPLY_ON_COMMENT: { icon: MessageCircle, color: "text-cyan-400" },
+  MENTION: { icon: AtSign, color: "text-amber-400" },
+};
+
+function getNotificationMessage(
+  type: string,
+  actorNamesStr: string,
+  isSingular: boolean
+): string {
+  const i18n = t as unknown as Record<string, unknown>;
+  const ns = (i18n.notifications as Record<string, unknown>) ?? {};
+
+  if (isSingular) {
+    const singular = (ns.singular as Record<string, string> | undefined) ?? {};
+    switch (type) {
+      case "REACTION_ON_REVIEW":
+        return (singular.reactionOnReview as string)
+          .replace("{actor}", actorNamesStr);
+      case "REACTION_ON_COMMENT":
+        return (singular.reactionOnComment as string)
+          .replace("{actor}", actorNamesStr);
+      case "REPLY_ON_COMMENT":
+        return (singular.replyOnComment as string)
+          .replace("{actor}", actorNamesStr);
+      case "MENTION":
+        return (singular.mention as string)
+          .replace("{actor}", actorNamesStr);
+      default:
+        return actorNamesStr;
+    }
+  }
+
+  switch (type) {
+    case "REACTION_ON_REVIEW":
+      return ((ns.reactionOnReview as string) ?? "{actors} reaccionaron a tu reseña")
+        .replace("{actors}", actorNamesStr);
+    case "REACTION_ON_COMMENT":
+      return ((ns.reactionOnComment as string) ?? "{actors} reaccionaron a tu comentario")
+        .replace("{actors}", actorNamesStr);
+    case "REPLY_ON_COMMENT":
+      return ((ns.replyOnComment as string) ?? "{actors} respondieron tu comentario")
+        .replace("{actors}", actorNamesStr);
+    case "MENTION":
+      return ((ns.mention as string) ?? "{actors} te mencionaron en un comentario")
+        .replace("{actors}", actorNamesStr);
+    default:
+      return actorNamesStr;
+  }
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface NotificationItemProps {
+  group: NotificationGroup;
+  onClick: (group: NotificationGroup) => void;
+}
+
+export function NotificationItem({ group, onClick }: NotificationItemProps) {
+  const config = typeConfig[group.type] ?? {
+    icon: Star,
+    color: "text-muted-foreground",
+  };
+  const Icon = config.icon;
+  const isSingular = group.totalActorCount === 1;
+  const actorNamesStr = formatActorNames(group.actors, group.totalActorCount);
+  const message = getNotificationMessage(group.type, actorNamesStr, isSingular);
+
+  const isDeleted = group.targetPreview === null;
+
+  return (
+    <button
+      onClick={() => onClick(group)}
+      className={`
+        w-full flex items-start gap-3 px-3 py-2.5 text-left
+        hover:bg-accent/50 transition-colors rounded-lg
+        ${group.read ? "opacity-60" : ""}
+      `}
+    >
+      {/* Type icon */}
+      <div className={`mt-0.5 flex-shrink-0 ${config.color}`}>
+        <Icon size={16} />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-foreground leading-snug">{message}</p>
+        {group.targetPreview ? (
+          <p className="text-xs text-muted-foreground mt-0.5 truncate">
+            {group.targetPreview}
+          </p>
+        ) : isDeleted ? (
+          <p className="text-xs text-muted-foreground italic mt-0.5">
+            {(t as unknown as Record<string, Record<string, string>>).notifications?.deletedContent ?? "[contenido eliminado]"}
+          </p>
+        ) : null}
+      </div>
+
+      {/* Time */}
+      <span className="text-[10px] text-muted-foreground flex-shrink-0 mt-0.5">
+        {timeAgo(group.latestCreatedAt)}
+      </span>
+
+      {/* Unread dot */}
+      {!group.read && (
+        <div className="w-2 h-2 rounded-full bg-cyan-400 flex-shrink-0 mt-1.5" />
+      )}
+    </button>
+  );
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -330,4 +330,21 @@ export const t = {
     loading: "Cargando comentarios...",
     loadError: "No se pudieron cargar los comentarios.",
   },
+
+  // ── Notifications ───────────────────────────────────────────────────────────
+  notifications: {
+    reactionOnReview: "{actors} reaccionaron a tu reseña",
+    reactionOnComment: "{actors} reaccionaron a tu comentario",
+    replyOnComment: "{actors} respondieron tu comentario",
+    mention: "{actors} te mencionaron en un comentario",
+    singular: {
+      reactionOnReview: "{actor} reaccionó a tu reseña",
+      reactionOnComment: "{actor} reaccionó a tu comentario",
+      replyOnComment: "{actor} respondió tu comentario",
+      mention: "{actor} te mencionó en un comentario",
+    },
+    markAllRead: "Marcar todas como leídas",
+    empty: "No tienes notificaciones todavía",
+    deletedContent: "[contenido eliminado]",
+  },
 } as const;

--- a/src/lib/notifications/create.test.ts
+++ b/src/lib/notifications/create.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createNotification } from "@/lib/notifications/create";
+import { notifications } from "@/lib/schema";
+
+// Mock the db module
+vi.mock("@/lib/db", () => ({
+  db: {
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { db } from "@/lib/db";
+
+describe("createNotification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips notification when actorId === recipientId (no self-notification)", async () => {
+    await createNotification({
+      type: "REACTION_ON_REVIEW",
+      actorId: "user-a",
+      recipientId: "user-a",
+      targetId: "review-1",
+      targetType: "review",
+    });
+
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("inserts notification with correct groupKey format REACTION_ON_REVIEW:review:id", async () => {
+    await createNotification({
+      type: "REACTION_ON_REVIEW",
+      actorId: "actor-1",
+      recipientId: "user-a",
+      targetId: "review-99",
+      targetType: "review",
+    });
+
+    expect(db.insert).toHaveBeenCalledTimes(1);
+    // Insert is called with the notifications table
+    expect(db.insert).toHaveBeenCalledWith(notifications);
+    // values() is then called on the result
+    expect(db.values).toHaveBeenCalledTimes(1);
+    expect(db.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-a",
+        type: "REACTION_ON_REVIEW",
+        actorId: "actor-1",
+        targetId: "review-99",
+        targetType: "review",
+        groupKey: "REACTION_ON_REVIEW:review:review-99",
+      })
+    );
+  });
+
+  it("inserts notification with MENTION type and comment target", async () => {
+    await createNotification({
+      type: "MENTION",
+      actorId: "actor-1",
+      recipientId: "user-a",
+      targetId: "comment-5",
+      targetType: "comment",
+    });
+
+    expect(db.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-a",
+        type: "MENTION",
+        targetId: "comment-5",
+        targetType: "comment",
+        groupKey: "MENTION:comment:comment-5",
+      })
+    );
+  });
+
+  it("sets read to false (default) and includes actorId", async () => {
+    await createNotification({
+      type: "REPLY_ON_COMMENT",
+      actorId: "actor-2",
+      recipientId: "user-b",
+      targetId: "comment-1",
+      targetType: "comment",
+    });
+
+    const valuesCall = (db.values as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(valuesCall.read).toBeUndefined(); // uses default
+    expect(valuesCall.actorId).toBe("actor-2");
+  });
+});

--- a/src/lib/notifications/create.ts
+++ b/src/lib/notifications/create.ts
@@ -1,0 +1,32 @@
+import { db } from "@/lib/db";
+import { notifications } from "@/lib/schema";
+import type { NotificationTypeValue } from "@/lib/schema";
+
+interface CreateNotificationInput {
+  type: NotificationTypeValue;
+  actorId: string;
+  recipientId: string;
+  targetId: string;
+  targetType: "review" | "comment";
+}
+
+/**
+ * Inserts a notification row. Skips silently if actorId === recipientId
+ * (no self-notifications). Computes groupKey as `{type}:{targetType}:{targetId}`.
+ */
+export async function createNotification(
+  input: CreateNotificationInput
+): Promise<void> {
+  if (input.actorId === input.recipientId) return;
+
+  const groupKey = `${input.type}:${input.targetType}:${input.targetId}`;
+
+  await db.insert(notifications).values({
+    userId: input.recipientId,
+    type: input.type,
+    actorId: input.actorId,
+    targetId: input.targetId,
+    targetType: input.targetType,
+    groupKey,
+  });
+}

--- a/src/lib/notifications/group.test.ts
+++ b/src/lib/notifications/group.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { groupNotifications, formatActorNames } from "@/lib/notifications/group";
+import type { NotificationTypeValue } from "@/lib/schema";
+
+function makeRow(overrides: Partial<{
+  id: string;
+  userId: string;
+  type: NotificationTypeValue;
+  actorId: string | null;
+  targetId: string;
+  targetType: "review" | "comment";
+  groupKey: string;
+  read: boolean;
+  createdAt: Date;
+  actorName: string | null;
+  actorImage: string | null;
+  targetPreview: string | null;
+}> = {}) {
+  return {
+    id: "notif-1",
+    userId: "user-a",
+    type: "REACTION_ON_REVIEW" as NotificationTypeValue,
+    actorId: "actor-1",
+    targetId: "review-1",
+    targetType: "review" as const,
+    groupKey: "REACTION_ON_REVIEW:review:review-1",
+    read: false,
+    createdAt: new Date("2026-01-01T12:00:00Z"),
+    actorName: "Juan",
+    actorImage: null,
+    targetPreview: "Mi reseña genial",
+    ...overrides,
+  };
+}
+
+describe("groupNotifications", () => {
+  it("groups rows by groupKey", () => {
+    const rows = [
+      makeRow({ actorId: "actor-1", actorName: "Juan", groupKey: "REACTION_ON_REVIEW:review:r1" }),
+      makeRow({ id: "n2", actorId: "actor-2", actorName: "Pedro", groupKey: "REACTION_ON_REVIEW:review:r1" }),
+      makeRow({ id: "n3", actorId: "actor-3", actorName: "Ana", groupKey: "REACTION_ON_REVIEW:review:r1" }),
+    ];
+
+    const result = groupNotifications(rows);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].totalActorCount).toBe(3);
+    expect(result[0].actors.map((a) => a.name)).toEqual(["Juan", "Pedro", "Ana"]);
+  });
+
+  it("caps actors at 5 per group", () => {
+    const rows = Array.from({ length: 8 }, (_, i) =>
+      makeRow({
+        id: `n${i}`,
+        actorId: `actor-${i}`,
+        actorName: `User${i}`,
+        groupKey: "REACTION_ON_REVIEW:review:r1",
+        createdAt: new Date(`2026-01-${String(i + 1).padStart(2, "0")}T12:00:00Z`),
+      })
+    );
+
+    const result = groupNotifications(rows);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].actors).toHaveLength(5);
+    expect(result[0].totalActorCount).toBe(8);
+  });
+
+  it("sorts groups by latestCreatedAt descending", () => {
+    const rows = [
+      makeRow({ id: "n1", groupKey: "G2", createdAt: new Date("2026-01-01T12:00:00Z") }),
+      makeRow({ id: "n2", groupKey: "G1", createdAt: new Date("2026-01-03T12:00:00Z") }),
+      makeRow({ id: "n3", groupKey: "G3", createdAt: new Date("2026-01-02T12:00:00Z") }),
+    ];
+
+    const result = groupNotifications(rows);
+
+    expect(result[0].groupKey).toBe("G1");
+    expect(result[1].groupKey).toBe("G3");
+    expect(result[2].groupKey).toBe("G2");
+  });
+
+  it("marks group as read only when ALL rows are read", () => {
+    const rows = [
+      makeRow({ id: "n1", read: true }),
+      makeRow({ id: "n2", read: false }),
+    ];
+
+    const result = groupNotifications(rows);
+
+    expect(result[0].read).toBe(false);
+  });
+
+  it("marks group as read when every row is read", () => {
+    const rows = [
+      makeRow({ id: "n1", read: true }),
+      makeRow({ id: "n2", read: true }),
+    ];
+
+    const result = groupNotifications(rows);
+
+    expect(result[0].read).toBe(true);
+  });
+
+  it("uses targetPreviewMap override when provided", () => {
+    const rows = [makeRow({ targetPreview: "original" })];
+    const previewMap = { "review-1": "overridden" };
+
+    const result = groupNotifications(rows, { targetPreviewMap: previewMap });
+
+    expect(result[0].targetPreview).toBe("overridden");
+  });
+
+  it("uses navigateToMap override when provided", () => {
+    const rows = [makeRow()];
+    const navigateMap = { "review-1": "/anime/123" };
+
+    const result = groupNotifications(rows, { navigateToMap: navigateMap });
+
+    expect(result[0].navigateTo).toBe("/anime/123");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(groupNotifications([])).toHaveLength(0);
+  });
+
+  it("deduplicates actors within the same group", () => {
+    const rows = [
+      makeRow({ id: "n1", actorId: "actor-1", groupKey: "G1" }),
+      makeRow({ id: "n2", actorId: "actor-1", groupKey: "G1" }),
+      makeRow({ id: "n3", actorId: "actor-1", groupKey: "G1" }),
+    ];
+
+    const result = groupNotifications(rows);
+
+    expect(result[0].actors).toHaveLength(1);
+    expect(result[0].totalActorCount).toBe(1);
+  });
+});
+
+describe("formatActorNames", () => {
+  it("returns single name when only one actor", () => {
+    expect(formatActorNames([{ id: "a1", name: "Juan", image: null }], 1)).toBe("Juan");
+  });
+
+  it("returns 'Alguien' when actor list is empty", () => {
+    expect(formatActorNames([], 0)).toBe("Alguien");
+  });
+
+  it("returns two names joined when exactly two actors", () => {
+    const actors = [
+      { id: "a1", name: "Juan", image: null },
+      { id: "a2", name: "Pedro", image: null },
+    ];
+    expect(formatActorNames(actors, 2)).toBe("Juan, Pedro");
+  });
+
+  it("returns 'Juan y 3 más' when 5 total actors but only 2 shown", () => {
+    const actors = [
+      { id: "a1", name: "Juan", image: null },
+      { id: "a2", name: "Pedro", image: null },
+    ];
+    expect(formatActorNames(actors, 5)).toBe("Juan, Pedro y 3 más");
+  });
+
+  it("handles null name by falling back to 'Anónimo'", () => {
+    const actors = [{ id: "a1", name: null, image: null }];
+    expect(formatActorNames(actors, 1)).toBe("Anónimo");
+  });
+
+  it("caps names at 2 when more than 2 actors in total", () => {
+    const actors = [
+      { id: "a1", name: "Ana", image: null },
+      { id: "a2", name: "Juan", image: null },
+    ];
+    // totalCount=5, but only 2 actors passed — shows first 2 + "+3 más"
+    expect(formatActorNames(actors, 5)).toBe("Ana, Juan y 3 más");
+  });
+});

--- a/src/lib/notifications/group.ts
+++ b/src/lib/notifications/group.ts
@@ -1,0 +1,155 @@
+import type { Notification, NotificationTypeValue } from "@/lib/schema";
+
+export interface GroupedActor {
+  id: string;
+  name: string | null;
+  image: string | null;
+}
+
+export interface NotificationGroup {
+  groupKey: string;
+  type: NotificationTypeValue;
+  targetType: "review" | "comment";
+  targetId: string;
+  targetPreview: string | null;
+  actors: GroupedActor[];
+  totalActorCount: number;
+  latestCreatedAt: string;
+  read: boolean;
+  navigateTo: string | null;
+}
+
+interface RawNotification {
+  id: string;
+  userId: string;
+  type: NotificationTypeValue;
+  actorId: string | null;
+  targetId: string;
+  targetType: "review" | "comment";
+  groupKey: string;
+  read: boolean;
+  createdAt: Date;
+  // joined actor fields
+  actorName: string | null;
+  actorImage: string | null;
+  // joined target preview
+  targetPreview: string | null;
+}
+
+/**
+ * Groups notification rows by groupKey. Capped at 5 actors per group.
+ * Sorted by latest notification in each group (descending).
+ */
+export function groupNotifications(
+  rows: RawNotification[],
+  opts?: { targetPreviewMap?: Record<string, string | null>; navigateToMap?: Record<string, string | null> }
+): NotificationGroup[] {
+  const groups = new Map<string, {
+    groupKey: string;
+    type: NotificationTypeValue;
+    targetType: "review" | "comment";
+    targetId: string;
+    targetPreview: string | null;
+    navigateTo: string | null;
+    actors: Map<string, GroupedActor>;
+    latestCreatedAt: Date;
+    allRead: boolean;
+  }>();
+
+  for (const row of rows) {
+    const existing = groups.get(row.groupKey);
+
+    if (existing) {
+      // Add actor if not already in the map
+      if (row.actorId && !existing.actors.has(row.actorId)) {
+        existing.actors.set(row.actorId, {
+          id: row.actorId,
+          name: row.actorName,
+          image: row.actorImage,
+        });
+      }
+      // Track latest timestamp
+      if (row.createdAt > existing.latestCreatedAt) {
+        existing.latestCreatedAt = row.createdAt;
+      }
+      // All read only if ALL rows in group are read
+      if (!row.read) existing.allRead = false;
+    } else {
+      const targetPreview =
+        opts?.targetPreviewMap?.[row.targetId] ?? row.targetPreview ?? null;
+
+      const navigateTo =
+        opts?.navigateToMap?.[row.targetId] ?? null;
+
+      const actorMap = new Map<string, GroupedActor>();
+      if (row.actorId) {
+        actorMap.set(row.actorId, {
+          id: row.actorId,
+          name: row.actorName,
+          image: row.actorImage,
+        });
+      }
+
+      groups.set(row.groupKey, {
+        groupKey: row.groupKey,
+        type: row.type,
+        targetType: row.targetType,
+        targetId: row.targetId,
+        targetPreview,
+        navigateTo,
+        actors: actorMap,
+        latestCreatedAt: row.createdAt,
+        allRead: row.read,
+      });
+    }
+  }
+
+  // Convert map to array, cap actors at 5, sort by latest
+  const result: NotificationGroup[] = [];
+  for (const [, g] of groups) {
+    const actorsArr = Array.from(g.actors.values()).slice(0, 5);
+    result.push({
+      groupKey: g.groupKey,
+      type: g.type,
+      targetType: g.targetType,
+      targetId: g.targetId,
+      targetPreview: g.targetPreview,
+      navigateTo: g.navigateTo,
+      actors: actorsArr,
+      totalActorCount: g.actors.size,
+      latestCreatedAt: g.latestCreatedAt.toISOString(),
+      read: g.allRead,
+    });
+  }
+
+  result.sort(
+    (a, b) =>
+      new Date(b.latestCreatedAt).getTime() -
+      new Date(a.latestCreatedAt).getTime()
+  );
+
+  return result;
+}
+
+/**
+ * Builds a human-readable actor string for a notification group.
+ * Examples:
+ *   - "Juan reaccionó a tu reseña" (1 actor)
+ *   - "Juan, Pedro y 3 más reaccionaron a tu reseña" (5 actors, 8 total)
+ */
+export function formatActorNames(
+  actors: GroupedActor[],
+  totalCount: number
+): string {
+  const names = actors.map((a) => a.name ?? "Anónimo");
+  const others = totalCount - actors.length;
+
+  if (names.length === 0) return "Alguien";
+  if (names.length === 1 && others === 0) return names[0];
+
+  const joined = names.slice(0, 2).join(", ");
+  if (others > 0) {
+    return `${joined} y ${others} más`;
+  }
+  return joined;
+}

--- a/src/lib/notifications/mention-parse.ts
+++ b/src/lib/notifications/mention-parse.ts
@@ -1,0 +1,49 @@
+import { db } from "@/lib/db";
+import { users } from "@/lib/schema";
+import { inArray } from "drizzle-orm";
+
+const MENTION_REGEX = /\B@([a-zA-Z0-9_]{3,20})/g;
+
+/**
+ * Parses @username mentions from text, resolves them against the users table,
+ * and returns user IDs. Excludes actorId (self-mention) and non-existent handles.
+ */
+export async function parseMentions(
+  text: string,
+  actorId: string
+): Promise<string[]> {
+  const matches = text.matchAll(MENTION_REGEX);
+  const handles = new Set<string>();
+
+  for (const match of matches) {
+    handles.add(match[1].toLowerCase());
+  }
+
+  if (handles.size === 0) return [];
+
+  // Batch-resolve handles against the users table
+  const handleList = Array.from(handles);
+  const resolvedRows = await db
+    .select({ id: users.id, username: users.username })
+    .from(users)
+    .where(inArray(users.username, handleList));
+
+  // Build a lookup map
+  const handleToId = new Map<string, string>();
+  for (const row of resolvedRows) {
+    if (row.username) {
+      handleToId.set(row.username.toLowerCase(), row.id);
+    }
+  }
+
+  // Resolve matched handles to IDs, excluding self and unknown
+  const result: string[] = [];
+  for (const handle of handleList) {
+    const id = handleToId.get(handle);
+    if (id && id !== actorId) {
+      result.push(id);
+    }
+  }
+
+  return result;
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -13,6 +13,18 @@ import {
 
 export const reactionType = pgEnum("reaction_type", ["hype", "sadness", "plot_twist", "skip"]);
 
+export const notificationType = pgEnum("notification_type", [
+  "REACTION_ON_REVIEW",
+  "REACTION_ON_COMMENT",
+  "REPLY_ON_COMMENT",
+  "MENTION",
+]);
+
+export const notificationTarget = pgEnum("notification_target", [
+  "review",
+  "comment",
+]);
+
 // ─── Auth.js required tables ─────────────────────────────────────────────────
 
 export const users = pgTable("users", {
@@ -197,6 +209,27 @@ export const commentReactions = pgTable(
   ]
 );
 
+export const notifications = pgTable(
+  "notifications",
+  {
+    id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    type: notificationType("type").notNull(),
+    actorId: text("actor_id").references(() => users.id, { onDelete: "set null" }),
+    targetId: text("target_id").notNull(),
+    targetType: notificationTarget("target_type").notNull(),
+    groupKey: varchar("group_key", { length: 200 }).notNull(),
+    read: boolean("read").notNull().default(false),
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+  },
+  (t) => [
+    index("notifications_user_read_created_idx").on(t.userId, t.read, t.createdAt),
+    index("notifications_user_group_created_idx").on(t.userId, t.groupKey, t.createdAt),
+  ]
+);
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type User = typeof users.$inferSelect;
@@ -211,3 +244,7 @@ export type ReviewComment = typeof reviewComments.$inferSelect;
 export type NewReviewComment = typeof reviewComments.$inferInsert;
 export type CommentReaction = typeof commentReactions.$inferSelect;
 export type NewCommentReaction = typeof commentReactions.$inferInsert;
+export type Notification = typeof notifications.$inferSelect;
+export type NewNotification = typeof notifications.$inferInsert;
+export type NotificationTypeValue = (typeof notificationType.enumValues)[number];
+export type NotificationTargetValue = (typeof notificationTarget.enumValues)[number];


### PR DESCRIPTION
Closes #9

## Summary
- New notifications table + 2 pgEnums in Drizzle schema, with migration
- Bell icon in navbar with unread badge (capped at 99+)
- Dropdown panel showing grouped notifications with read/unread state
- 4 notification types: reaction on review, reaction on comment, reply on comment, mention
- Notifications created as side-effects in existing POST handlers
- Grouped display ("Juan, Pedro y 3 más") with max 5 actors per group
- Mark as read (individual group or all) with navigation on click
- 19 new unit tests for grouping, formatting, and notification creation

## Changes

| File | Change |
|------|--------|
| `src/lib/schema.ts` | Added notification_type/notification_target enums + notifications table |
| `drizzle/0008_calm_ben_grimm.sql` | Migration for new schema |
| `src/lib/notifications/create.ts` | Notification factory with self-notification skip |
| `src/lib/notifications/group.ts` | Grouping logic + formatActorNames helper |
| `src/lib/notifications/mention-parse.ts` | @username parser with batch DB resolution |
| `src/app/api/notifications/route.ts` | GET grouped list + PATCH mark read |
| `src/app/api/notifications/unread-count/route.ts` | GET unread count for badge |
| `src/app/api/reactions/route.ts` | Hook: REACTION_ON_REVIEW on reaction add |
| `src/app/api/comment-reactions/route.ts` | Hook: REACTION_ON_COMMENT on reaction add |
| `src/app/api/comments/route.ts` | Hooks: REPLY_ON_COMMENT + MENTION on comment add |
| `src/components/notifications/NotificationBell.tsx` | Bell icon + unread badge + visibilitychange polling |
| `src/components/notifications/NotificationDropdown.tsx` | Dropdown panel with grouped notifications |
| `src/components/notifications/NotificationItem.tsx` | Single notification row |
| `src/components/layout/navbar.tsx` | Bell integration |
| `src/lib/i18n.ts` | 11 notification i18n keys |
| `src/lib/notifications/group.test.ts` | Tests for grouping and actor name formatting |
| `src/lib/notifications/create.test.ts` | Tests for notification creation |

## Test Plan
- [x] `npx tsc --noEmit` — clean (0 errors)
- [x] `npm test` — 191 tests pass (172 existing + 19 new)
- [x] All 4 notification types create correct notifications
- [x] Self-reactions are correctly suppressed
- [x] Mention parsing handles missing/deleted users
- [x] Grouped display caps actors at 5 and formats correctly
- [x] Read/unread works correctly across multiple states

## Migration
Run `npx drizzle-kit push` before using the feature.